### PR TITLE
add alternative label placement.

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -345,3 +345,37 @@ body {
     padding-left: 10px;
   }
 }
+
+.@{stepsPrefixClass}-label-vertical {
+  .@{stepsPrefixClass}-tail {
+    padding: 0 32px;
+  }
+  .@{stepsPrefixClass}-item {
+    .@{stepsPrefixClass}-step {
+      display: inline-block;
+      text-align: center;
+    }
+  }
+  .@{stepsPrefixClass}-item:not(:first-child) .@{stepsPrefixClass}-head {
+    margin-left: 0;
+    padding-left: 0;
+  }
+  .@{stepsPrefixClass}-head {
+    display: inline-block;
+    padding-right: 10px;
+    &-inner {
+      margin: 0 auto;
+    }
+  }
+  .@{stepsPrefixClass}-main {
+    display: block;
+    margin-top: 10px;
+    .@{stepsPrefixClass}-title {
+      padding-right: 0;
+    }
+    .@{stepsPrefixClass}-description {
+      text-align: left;
+    }
+  }
+
+}

--- a/examples/alternativeLabel.html
+++ b/examples/alternativeLabel.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/alternativeLabel.js
+++ b/examples/alternativeLabel.js
@@ -1,0 +1,37 @@
+require('rc-steps/assets/index.less');
+require('rc-steps/assets/iconfont.less');
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Steps = require('rc-steps');
+
+const container = document.getElementById('__react-content');
+
+const steps = [{
+  status: 'finish',
+  title: '已完成',
+  description: '这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊',
+}, {
+  status: 'process',
+  title: '进行中',
+  description: '这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊',
+}, {
+  status: 'wait',
+  title: '待运行',
+  description: '这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊这里是多信息的描述啊',
+}].map((s, i) => {
+  return (
+    <Steps.Step
+      key={i}
+      status={s.status}
+      title={s.title}
+      description={s.description}
+    />
+  );
+});
+
+ReactDOM.render(
+  <Steps labelPlacement="vertical">
+    {steps}
+  </Steps>
+, container);

--- a/src/Step.jsx
+++ b/src/Step.jsx
@@ -30,12 +30,14 @@ function Step(props) {
       style={{ width: tailWidth, marginRight: adjustMarginRight, ...style }}
     >
       {stepLast ? '' : <div className={`${prefixCls}-tail`}><i /></div>}
-      <div className={`${prefixCls}-head`}>
-        <div className={`${prefixCls}-head-inner`}>{iconNode}</div>
-      </div>
-      <div className={`${prefixCls}-main`}>
-        <div className={`${prefixCls}-title`}>{title}</div>
-        {description ? <div className={`${prefixCls}-description`}>{description}</div> : ''}
+      <div className={`${prefixCls}-step`}>
+        <div className={`${prefixCls}-head`}>
+          <div className={`${prefixCls}-head-inner`}>{iconNode}</div>
+        </div>
+        <div className={`${prefixCls}-main`}>
+          <div className={`${prefixCls}-title`}>{title}</div>
+          {description ? <div className={`${prefixCls}-description`}>{description}</div> : ''}
+        </div>
       </div>
     </div>
   );

--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -29,13 +29,14 @@ export default class Steps extends React.Component {
   }
   render() {
     const props = this.props;
-    const { prefixCls, className, children, direction,
+    const { prefixCls, className, children, direction, labelPlacement,
             iconPrefix, status, size, ...restProps } = props;
     const lastIndex = children.length - 1;
     const classString = classNames({
       [prefixCls]: true,
       [`${prefixCls}-${size}`]: size,
       [`${prefixCls}-${direction}`]: true,
+      [`${prefixCls}-label-${labelPlacement}`]: direction === 'horizontal',
       [`${prefixCls}-hidden`]: this.state.lastStepOffsetWidth === 0,
       [className]: className,
     });
@@ -44,9 +45,9 @@ export default class Steps extends React.Component {
       <div className={classString} {...restProps}>
         {
           React.Children.map(children, (ele, idx) => {
-            const tailWidth = (props.direction === 'vertical' || idx === lastIndex)
+            const tailWidth = (direction === 'vertical' || idx === lastIndex)
               ? null : `${100 / lastIndex}%`;
-            const adjustMarginRight = (props.direction === 'vertical' || idx === lastIndex)
+            const adjustMarginRight = (direction === 'vertical' || idx === lastIndex)
               ? null : -(this.state.lastStepOffsetWidth / lastIndex + 1);
             const np = {
               stepNumber: (idx + 1).toString(),
@@ -83,6 +84,7 @@ Steps.propTypes = {
   prefixCls: PropTypes.string,
   iconPrefix: PropTypes.string,
   direction: PropTypes.string,
+  labelPlacement: PropTypes.string,
   children: PropTypes.any,
   status: PropTypes.string,
   size: PropTypes.string,
@@ -92,6 +94,7 @@ Steps.defaultProps = {
   prefixCls: 'rc-steps',
   iconPrefix: 'rc',
   direction: 'horizontal',
+  labelPlacement: 'horizontal',
   current: 0,
   status: 'process',
   size: '',


### PR DESCRIPTION
ant mobile will add a lable-vertical-featured steps, just like material design.

![image](https://cloud.githubusercontent.com/assets/1279425/14846871/7c527fe8-0c98-11e6-888c-9ca530bcdf55.png)

and the example goes

![image](https://cloud.githubusercontent.com/assets/1279425/14846961/cff6a156-0c98-11e6-9650-eb43f5fa62cd.png)
