### PR TITLE
Cancel previous timeout before setting a new one

### DIFF
--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -10,20 +10,23 @@ export default class Steps extends React.Component {
     };
   }
   componentDidMount() {
-    this.culcLastStepOffsetWidth();
+    this.calcLastStepOffsetWidth();
   }
   componentDidUpdate() {
-    this.culcLastStepOffsetWidth();
+    this.calcLastStepOffsetWidth();
   }
   componentWillUnmount() {
-    if (this.culcTimeout) {
-      clearTimeout(this.culcTimeout);
+    if (this.calcTimeout) {
+      clearTimeout(this.calcTimeout);
     }
   }
-  culcLastStepOffsetWidth = () => {
+  calcLastStepOffsetWidth = () => {
     const domNode = ReactDOM.findDOMNode(this);
     if (domNode.children.length > 0) {
-      this.culcTimeout = setTimeout(() => {
+      if (this.calcTimeout) {
+        clearTimeout(this.calcTimeout);
+      }
+      this.calcTimeout = setTimeout(() => {
         // +1 for fit edge bug of digit width, like 35.4px
         const lastStepOffsetWidth = domNode.lastChild.offsetWidth + 1;
         if (this.state.lastStepOffsetWidth === lastStepOffsetWidth) {


### PR DESCRIPTION
I have used this component in my app and sometimes I am getting the following warning

`
warning.js:36 Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Steps component.
`

I checked the code of Steps component and figured out, that when Steps component updates so often, the `calcTimeout` is being fired more than once. When I added a check, that we have canceled the previous timeout, the error has gone.