### PR TITLE
Fix variable spelling error.

### DIFF
--- a/assets/variables.less
+++ b/assets/variables.less
@@ -6,7 +6,7 @@
 @process-description-color: @process-title-color;
 @process-tail-color: #e9e9e9;
 @wait-icon-color: #ccc;
-@wait-title-color: gba(0,0,0,.43);
+@wait-title-color: rgba(0,0,0,.43);
 @wait-description-color: @wait-title-color;
 @wait-tail-color: @process-tail-color;
 @finish-icon-color: @process-icon-color;


### PR DESCRIPTION
thanks for nice project, but I found label's color under `rc-steps-item-wait` not render correctly.
I change the variable `@wait-title-color` in `/assets/variables.less`, so it get well. 😄 