### PR TITLE
Fix status icon issue

### DIFF
--- a/src/Step.jsx
+++ b/src/Step.jsx
@@ -44,8 +44,8 @@ export default class Step extends React.Component {
     let iconNode;
     const iconClassName = classNames(`${prefixCls}-icon`, `${iconPrefix}icon`, {
       [`${iconPrefix}icon-${icon}`]: icon && isString(icon),
-      [`${iconPrefix}icon-check`]: !icon && status === 'finish' && (icons && !icons.finish),
-      [`${iconPrefix}icon-close`]: !icon && status === 'error' && (icons && !icons.error),
+      [`${iconPrefix}icon-check`]: !icon && status === 'finish' && (!icons || (icons && !icons.finish)),
+      [`${iconPrefix}icon-close`]: !icon && status === 'error' && (!icons || (icons && !icons.error)),
     });
     const iconDot = <span className={`${prefixCls}-icon-dot`}></span>;
     // `progressDot` enjoy the highest priority


### PR DESCRIPTION
Currently if one specifies `status='finish'` for example, the icon is not displayed because of erroneous conditional statement. Hence, one also needs to include something like an empty object for icons, such as `icons={{}}`, in order for the icon to be successfully displayed. This fixes that issue.