### PR TITLE
fix: fix default finish and error icon won't show as expected

### DIFF
--- a/src/Step.jsx
+++ b/src/Step.jsx
@@ -59,8 +59,8 @@ export default class Step extends React.Component {
     let iconNode;
     const iconClassName = classNames(`${prefixCls}-icon`, `${iconPrefix}icon`, {
       [`${iconPrefix}icon-${icon}`]: icon && isString(icon),
-      [`${iconPrefix}icon-check`]: !icon && status === 'finish' && (icons && !icons.finish),
-      [`${iconPrefix}icon-close`]: !icon && status === 'error' && (icons && !icons.error),
+      [`${iconPrefix}icon-check`]: !icon && status === 'finish' && ((icons && !icons.finish) || !icons),
+      [`${iconPrefix}icon-cross`]: !icon && status === 'error' && ((icons && !icons.error) || !icons),
     });
     const iconDot = <span className={`${prefixCls}-icon-dot`} />;
     // `progressDot` enjoy the highest priority


### PR DESCRIPTION
Fix the icon display problem.

The default finish and error icon won't be displayed.

close #51