### PR TITLE
fix: remove subTitle's title attribute

### DIFF
--- a/src/Step.jsx
+++ b/src/Step.jsx
@@ -148,11 +148,7 @@ export default class Step extends React.Component {
           <div className={`${prefixCls}-item-content`}>
             <div className={`${prefixCls}-item-title`}>
               {title}
-              {subTitle && (
-                <div title={subTitle} className={`${prefixCls}-item-subtitle`}>
-                  {subTitle}
-                </div>
-              )}
+              {subTitle && <div className={`${prefixCls}-item-subtitle`}>{subTitle}</div>}
             </div>
             {description && <div className={`${prefixCls}-item-description`}>{description}</div>}
           </div>

--- a/src/Step.jsx
+++ b/src/Step.jsx
@@ -148,7 +148,14 @@ export default class Step extends React.Component {
           <div className={`${prefixCls}-item-content`}>
             <div className={`${prefixCls}-item-title`}>
               {title}
-              {subTitle && <div className={`${prefixCls}-item-subtitle`}>{subTitle}</div>}
+              {subTitle && (
+                <div
+                  title={typeof subTitle === 'string' ? subTitle : undefined}
+                  className={`${prefixCls}-item-subtitle`}
+                >
+                  {subTitle}
+                </div>
+              )}
             </div>
             {description && <div className={`${prefixCls}-item-description`}>{description}</div>}
           </div>


### PR DESCRIPTION
type of `subTitle` is incompatible with `title` attribute which can only accepts `string` type
fix: https://github.com/ant-design/ant-design/issues/23960