### PR TITLE
fix: step is wrapped in fragments

### DIFF
--- a/src/Step.tsx
+++ b/src/Step.tsx
@@ -176,6 +176,6 @@ export default class Step extends React.Component<StepProps> {
       stepNode = render(stepNode) || null;
     }
 
-    return stepNode;
+    return stepNode as React.ReactElement;
   }
 }


### PR DESCRIPTION
修复 Step typescirpt warning
`'Steps.Step' cannot be used as a JSX component.
  Its instance type 'Step' is not a valid JSX element.`