### PR TITLE
refactor: replace labelPlacement with titlePlacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ https://steps.vercel.app/
       <td>size of Steps, could be `small`</td>
     </tr>
     <tr>
-      <td>labelPlacement</td>
+      <td>titlePlacement</td>
       <td>string</td>
       <td></td>
       <td>placement of step title, could be `vertical`</td>

--- a/docs/examples/alternativeLabel.jsx
+++ b/docs/examples/alternativeLabel.jsx
@@ -8,7 +8,7 @@ const description =
 
 export default () => (
   <Steps
-    labelPlacement="vertical"
+    titlePlacement="vertical"
     current={1}
     items={[
       {

--- a/src/Steps.tsx
+++ b/src/Steps.tsx
@@ -55,7 +55,7 @@ export interface StepsProps {
 
   // layout
   orientation?: 'horizontal' | 'vertical';
-  labelPlacement?: 'horizontal' | 'vertical';
+  titlePlacement?: 'horizontal' | 'vertical';
 
   // data
   status?: Status;
@@ -82,7 +82,7 @@ export default function Steps(props: StepsProps) {
 
     // layout
     orientation = 'horizontal',
-    labelPlacement = 'horizontal',
+    titlePlacement = 'horizontal',
 
     // data
     status = 'process',
@@ -102,14 +102,14 @@ export default function Steps(props: StepsProps) {
   // ============================= layout =============================
   const isVertical = orientation === 'vertical';
   const mergedOrientation = isVertical ? 'vertical' : 'horizontal';
-  const mergeLabelPlacement =
-    !isVertical && labelPlacement === 'vertical' ? 'vertical' : 'horizontal';
+  const mergeTitlePlacement =
+    !isVertical && titlePlacement === 'vertical' ? 'vertical' : 'horizontal';
 
   // ============================= styles =============================
   const classString = cls(
     prefixCls,
     `${prefixCls}-${mergedOrientation}`,
-    `${prefixCls}-label-${mergeLabelPlacement}`,
+    `${prefixCls}-title-${mergeTitlePlacement}`,
     rootClassName,
     className,
     classNames.root,

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Steps render renders correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-process rc-steps-item-active"
@@ -114,7 +114,7 @@ exports[`Steps render renders correctly 1`] = `
 
 exports[`Steps render renders current correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-finish"
@@ -224,121 +224,9 @@ exports[`Steps render renders current correctly 1`] = `
 </div>
 `;
 
-exports[`Steps render renders labelPlacement correctly 1`] = `
-<div
-  class="rc-steps rc-steps-horizontal rc-steps-label-vertical"
->
-  <div
-    class="rc-steps-item rc-steps-item-process rc-steps-item-active"
-  >
-    <div
-      class="rc-steps-item-wrapper"
-    >
-      <div
-        class="rc-steps-item-icon"
-      />
-      <div
-        class="rc-steps-item-section"
-      >
-        <div
-          class="rc-steps-item-header"
-        >
-          <div
-            class="rc-steps-item-title"
-          >
-            已完成
-          </div>
-          <div
-            class="rc-steps-item-rail rc-steps-item-rail-wait"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="rc-steps-item rc-steps-item-wait"
-  >
-    <div
-      class="rc-steps-item-wrapper"
-    >
-      <div
-        class="rc-steps-item-icon"
-      />
-      <div
-        class="rc-steps-item-section"
-      >
-        <div
-          class="rc-steps-item-header"
-        >
-          <div
-            class="rc-steps-item-title"
-          >
-            进行中
-          </div>
-          <div
-            class="rc-steps-item-rail rc-steps-item-rail-wait"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="rc-steps-item rc-steps-item-wait"
-  >
-    <div
-      class="rc-steps-item-wrapper"
-    >
-      <div
-        class="rc-steps-item-icon"
-      />
-      <div
-        class="rc-steps-item-section"
-      >
-        <div
-          class="rc-steps-item-header"
-        >
-          <div
-            class="rc-steps-item-title"
-          >
-            待运行
-          </div>
-          <div
-            class="rc-steps-item-rail rc-steps-item-rail-wait"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="rc-steps-item rc-steps-item-wait"
-  >
-    <div
-      class="rc-steps-item-wrapper"
-    >
-      <div
-        class="rc-steps-item-icon"
-      />
-      <div
-        class="rc-steps-item-section"
-      >
-        <div
-          class="rc-steps-item-header"
-        >
-          <div
-            class="rc-steps-item-title"
-          >
-            待运行
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Steps render renders progressDot correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-process rc-steps-item-active"
@@ -450,7 +338,7 @@ exports[`Steps render renders progressDot correctly 1`] = `
 
 exports[`Steps render renders progressDot function correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-process rc-steps-item-active"
@@ -562,7 +450,7 @@ exports[`Steps render renders progressDot function correctly 1`] = `
 
 exports[`Steps render renders status correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-finish"
@@ -674,7 +562,7 @@ exports[`Steps render renders status correctly 1`] = `
 
 exports[`Steps render renders step with description 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-process rc-steps-item-active"
@@ -806,7 +694,7 @@ exports[`Steps render renders step with description 1`] = `
 
 exports[`Steps render renders step with description and status 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-wait rc-steps-item-active"
@@ -938,7 +826,119 @@ exports[`Steps render renders step with description and status 1`] = `
 
 exports[`Steps render renders stepIcon function correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
+>
+  <div
+    class="rc-steps-item rc-steps-item-process rc-steps-item-active"
+  >
+    <div
+      class="rc-steps-item-wrapper"
+    >
+      <div
+        class="rc-steps-item-icon"
+      />
+      <div
+        class="rc-steps-item-section"
+      >
+        <div
+          class="rc-steps-item-header"
+        >
+          <div
+            class="rc-steps-item-title"
+          >
+            已完成
+          </div>
+          <div
+            class="rc-steps-item-rail rc-steps-item-rail-wait"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="rc-steps-item rc-steps-item-wait"
+  >
+    <div
+      class="rc-steps-item-wrapper"
+    >
+      <div
+        class="rc-steps-item-icon"
+      />
+      <div
+        class="rc-steps-item-section"
+      >
+        <div
+          class="rc-steps-item-header"
+        >
+          <div
+            class="rc-steps-item-title"
+          >
+            进行中
+          </div>
+          <div
+            class="rc-steps-item-rail rc-steps-item-rail-wait"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="rc-steps-item rc-steps-item-wait"
+  >
+    <div
+      class="rc-steps-item-wrapper"
+    >
+      <div
+        class="rc-steps-item-icon"
+      />
+      <div
+        class="rc-steps-item-section"
+      >
+        <div
+          class="rc-steps-item-header"
+        >
+          <div
+            class="rc-steps-item-title"
+          >
+            待运行
+          </div>
+          <div
+            class="rc-steps-item-rail rc-steps-item-rail-wait"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="rc-steps-item rc-steps-item-wait"
+  >
+    <div
+      class="rc-steps-item-wrapper"
+    >
+      <div
+        class="rc-steps-item-icon"
+      />
+      <div
+        class="rc-steps-item-section"
+      >
+        <div
+          class="rc-steps-item-header"
+        >
+          <div
+            class="rc-steps-item-title"
+          >
+            待运行
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Steps render renders titlePlacement correctly 1`] = `
+<div
+  class="rc-steps rc-steps-horizontal rc-steps-title-vertical"
 >
   <div
     class="rc-steps-item rc-steps-item-process rc-steps-item-active"
@@ -1050,7 +1050,7 @@ exports[`Steps render renders stepIcon function correctly 1`] = `
 
 exports[`Steps render renders vertical correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
   direction="vertical"
 >
   <div
@@ -1163,7 +1163,7 @@ exports[`Steps render renders vertical correctly 1`] = `
 
 exports[`Steps render renders with falsy children 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-wait rc-steps-item-active"
@@ -1301,7 +1301,7 @@ exports[`Steps render renders with falsy children 1`] = `
 
 exports[`Steps should render customIcon correctly 1`] = `
 <div
-  class="rc-steps rc-steps-horizontal rc-steps-label-horizontal"
+  class="rc-steps rc-steps-horizontal rc-steps-title-horizontal"
 >
   <div
     class="rc-steps-item rc-steps-item-finish rc-steps-item-custom"

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -52,8 +52,8 @@ describe('Steps', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    it('renders labelPlacement correctly', () => {
-      const { container } = render(setSteps({ labelPlacement: 'vertical' }));
+    it('renders titlePlacement correctly', () => {
+      const { container } = render(setSteps({ titlePlacement: 'vertical' }));
       expect(container.firstChild).toMatchSnapshot();
     });
 


### PR DESCRIPTION
follow https://github.com/ant-design/ant-design/discussions/53328 to move to `titlePlacement`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新了 Steps 组件的 API 文档，将属性名从 labelPlacement 更正为 titlePlacement。
- **新特性**
  - Steps 组件的属性名由 labelPlacement 改为 titlePlacement，用于控制步骤标题的排列方式。
- **测试**
  - 测试用例同步更新为使用 titlePlacement 属性，确保与组件属性一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->