### PR TITLE
Avoid util deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     ]
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.6",

--- a/src/Step.tsx
+++ b/src/Step.tsx
@@ -1,7 +1,7 @@
 /* eslint react/prop-types: 0 */
 import * as React from 'react';
 import { clsx } from 'clsx';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import type { Status, StepItem, StepsProps } from './Steps';
 import Rail from './Rail';
 import { UnstableContext } from './UnstableContext';

--- a/src/StepIcon.tsx
+++ b/src/StepIcon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 import { StepsContext } from './Context';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 
 export interface StepIconSemanticContextProps {
   className?: string;

--- a/src/StepIcon.tsx
+++ b/src/StepIcon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
-import { StepsContext } from './Context';
 import { pickAttrs } from '@rc-component/util';
+import { StepsContext } from './Context';
 
 export interface StepIconSemanticContextProps {
   className?: string;


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到当前 latest `^1.11.1`。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`，交由插件统一处理 rc 深路径 import 限制。
- 将源码中对 `@rc-component/util/lib/*` 的引用改为从 `@rc-component/util` 根入口导入。

## 背景

配合 rc 包统一避免依赖其他 rc 包的 `es` / `lib` 构建产物内部路径，改为使用公开根入口 API。

## 验证

- `git diff --check`
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级若干构建与工具依赖版本以保持兼容性与安全性。
  * 统一模块导入为包入口导出，替换深层路径引用以简化构建和维护。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/steps/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->